### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ numpy>=1.21
 opencv-python
 pandas
 Pillow
-scikit-image==0.16.2
+scikit-image==0.18.0
 tensorboard
 tensorboardX
 tifffile==2020.9.3


### PR DESCRIPTION
I was curious about the project. 
I ran it on google collab and noticed that it is unable to work with  scikit-image==0.16.2 version.
As this version doesn't contain skimage.draw.circle method needed to run the code.

Although, the updated scikit-image==0.18.0 does

I would suggest to verify it by your own for both the versions and decide to include the change.

Regards